### PR TITLE
HUSH-3250 httpie_hush: don't err on "Invalid auth arguments" if no --auth was set

### DIFF
--- a/httpie_hush.py
+++ b/httpie_hush.py
@@ -170,7 +170,7 @@ class HushAuthPlugin(AuthPlugin):
     auth_require = False
 
     def get_auth(self, username=None, password=None):
-        parts = self.raw_auth.split(":") if self.raw_auth else []
+        parts = self.raw_auth.split(":") if self.raw_auth else ["", ""]
         if not 2 <= len(parts) <= 4:
             print("Invalid auth arguments provided")
             sys.exit(ExitStatus.PLUGIN_ERROR)


### PR DESCRIPTION
This assertion:
```
        parts = self.raw_auth.split(":") if self.raw_auth else []
        if not 2 <= len(parts) <= 4:
            print("Invalid auth arguments provided")
```
is tested against [] if raw_auth is unset, which is guaranteed to
fail.
This prevents using the plugin without providing --auth, even if
user/pass env vars are properly set.

Instead, the default parts should be `["", ""]` (empty user, empty pass).
This way, the assertion will be ignored for an empty raw_auth.

User can invoke the command without passing --auth, and the following
assignmets work:
```
        username = parts[0] or username or os.getenv("HTTPIE_HUSH_USERNAME")
        password = parts[1] or password or os.getenv("HTTPIE_HUSH_PASSWORD")
```